### PR TITLE
Dockerfile: Use dtc 1.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN apt-get -y update && \
 	valgrind \
 	wget \
 	xz-utils && \
+	wget -O dtc.deb http://security.ubuntu.com/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb && \
+	dpkg -i dtc.deb && \
+	rm dtc.deb && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \


### PR DESCRIPTION
The Zephyr build system now requires dtc-1.4.7. This isn't in Bionic
so we have to pull the deb directly from security pool.

Signed-off-by: Andy Doan <andy@foundries.io>