### PR TITLE
Updated documentation on display use

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ and can be used for development and building zephyr samples and tests,
 for example:
 
 ```
-docker run -ti -v <path to zephyr tree>:/workdir \
-zephyr_doc:v<tag> /bin/bash
+docker run -ti -v <path to zephyr tree>:/workdir zephyr_doc:v<tag>
 ```
 
 Then, follow the steps below to build a sample application:
@@ -30,8 +29,8 @@ The image is also available on docker.io, so you can skip the build step
 and directly pull from docker.io and build:
 
 ```
-docker run -ti -v $HOME/Work/github/zephyr:/workdir
-docker.io/zephyrprojectrtos/zephyr-build:latest /bin/bash
+docker run -ti -v $HOME/Work/github/zephyr:/workdir \
+docker.io/zephyrprojectrtos/zephyr-build:latest
 ```
 
 The environment is set and ready to go, no need to source zephyr-env.sh.
@@ -41,3 +40,35 @@ We have two toolchains installed:
 - GNU Arm Embedded Toolchain
 
 To switch, set ZEPHYR_TOOLCHAIN_VARIANT.
+
+Further it is possible to run _native POSIX_ samples that require a display
+and check the display output via a VNC client. To allow the VNC client to
+connect to the docker instance port 5900 needs to be forwarded to the host,
+for example:
+
+```
+docker run -ti -p 5900:5900 -v <path to zephyr tree>:/workdir zephyr_doc:v<tag>
+```
+
+Then, follow the steps below to build a display sample application for the
+_native POSIX_ board:
+
+```
+cd samples/display/cfb
+mkdir build
+cd build
+cmake -DBOARD=native_posix -GNinja ..
+ninja run
+```
+
+The result can be observed by connecting a VNC client to _localhost_ at port
+_5900_, the default VNC password is _zephyr_.
+
+For example on a Ubuntu host system:
+
+```
+vncviewer localhost:5900
+```
+
+
+


### PR DESCRIPTION
Updated documentation on how the view, run and build native POSIX
samples that require a display.