### PR TITLE
Dockerfile: Added dos2unix and convert entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN dpkg --add-architecture i386 && \
 	ccache \
 	device-tree-compiler \
 	dfu-util \
+	dos2unix \
 	doxygen \
 	file \
 	g++ \
@@ -108,6 +109,7 @@ ENV DISPLAY=:0
 RUN chown -R user:user /home/user
 
 ADD ./entrypoint.sh /home/user/entrypoint.sh
+RUN dos2unix /home/user/entrypoint.sh
 
 EXPOSE 5900
 


### PR DESCRIPTION
Install dos2unix command and run dos2unix on the entry point script.
This is need to guarantee that the entry point script is using Unix
line ending, if this is not the case the container will fail to
start.

Note that even if the entry point script is checked in with Unix line
ending cloning the repo on a windows system can change the line
ending to DOS depending on how git is installed on windows.
By default git will convert from Unix to DOS line ending while files
are checkout and convert back to Unix line ending on check in.

Fixes: #10

Signed-off-by: Jan Van Winkel <jan.van_winkel@dxplore.eu>