### PR TITLE
python: add python3-dev package needed by build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN dpkg --add-architecture i386 && \
 	ninja-build \
 	openbox \
 	pkg-config \
+	python3-dev \
 	python3-pip \
 	python3-ply \
 	python3-setuptools \


### PR DESCRIPTION
Build process exited with error because don't found Python.h provided by python3-dev package 