### PR TITLE
Dockerfile: Fix requirements download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,12 +79,9 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 
-RUN wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \
-	cat requirements.txt | sed "s?^-r ?https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/?g" | xargs wget -q && \
-	pip3 install wheel &&\
-	pip3 install -r requirements.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt -O mcuboot_requirements.txt && \
-	pip3 install -r mcuboot_requirements.txt && \
+RUN pip3 install wheel &&\
+	pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \
+	pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt && \
 	pip3 install west &&\
 	pip3 install sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ RUN wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/s
 	cat requirements.txt | sed "s?^-r ?https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/?g" | xargs wget -q && \
 	pip3 install wheel &&\
 	pip3 install -r requirements.txt && \
+	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt -O mcuboot_requirements.txt && \
+	pip3 install -r mcuboot_requirements.txt && \
 	pip3 install west &&\
 	pip3 install sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,7 @@ ENV LC_ALL en_US.UTF-8
 
 
 RUN wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements-base.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements-build-test.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements-doc.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements-run-test.txt && \
-	wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements-extras.txt && \
+	cat requirements.txt | sed "s?^-r ?https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/?g" | xargs wget -q && \
 	pip3 install wheel &&\
 	pip3 install -r requirements.txt && \
 	pip3 install west &&\


### PR DESCRIPTION
SOLVED: modified requirements.txt breaks docker build due to manual download of sub-requirements files
ADDED: installing requirements from zephyrproject-rtos/mcuboot

Signed-off-by: John Grey <greyjohn734@gmail.com>