### PR TITLE
Dockerfile: Add g++-multilib to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install --no-install-recommends -y \
 	g++ \
 	gcc \
 	gcc-multilib \
+	g++-multilib \
 	gcovr \
 	git \
 	git-core \


### PR DESCRIPTION
This commit adds the `g++-multilib` package to the docker image, which will fix build errors for some 32-bit platforms if we use this docker image to build test cases on 64-bit machines.

Fixes: https://github.com/zephyrproject-rtos/docker-image/issues/48

Signed-off-by: Henry Wang <<Henry.Wang@arm.com>>