### PR TITLE
Added xterm among installation packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get install --no-install-recommends -y \
 	texinfo \
 	valgrind \
 	x11vnc \
+	xterm \
 	xvfb \
 	xz-utils && \
 	apt install -y ./renode_${RENODE_VERSION}_amd64.deb && \


### PR DESCRIPTION
Added xterm among installation packages in the Dockerfile so you can run the native posix code while monitoring the UART output. Run the docker container with the relevant DISPLAY environment variable and X11 enabled on the host.