### PR TITLE
Dockerfile: add libssl-dev for rimage / SOF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN dpkg --add-architecture i386 && \
 	libsdl2-dev:i386 \
 	libsdl1.2-dev \
 	libsdl2-dev \
+	libssl-dev \
 	libtool \
 	locales \
 	make \


### PR DESCRIPTION
openssl is a dependency of rimage which is a dependency of SOF

Signed-off-by: Marc Herbert <marc.herbert@intel.com>