### PR TITLE
do not autoremove packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,6 @@ RUN dpkg --add-architecture i386 && \
 	valgrind \
 	wget \
 	xz-utils && \
-	apt remove libclang1-10 -y && \
-	apt autoremove -y && \
 	wget ${WGET_ARGS} https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
 	apt install -y ./renode_${RENODE_VERSION}_amd64.deb && \
 	rm renode_${RENODE_VERSION}_amd64.deb && \


### PR DESCRIPTION
doxygen is being removed when clang-10 is uninstalled, do not autoremove
packages to avoid unwanted side effects.