### PR TITLE
image: add uefi-run and ovmf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN dpkg --add-architecture i386 && \
 	unzip \
 	valgrind \
 	wget \
+	ovmf \
 	xz-utils && \
 	wget ${WGET_ARGS} https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
 	apt install -y ./renode_${RENODE_VERSION}_amd64.deb && \
@@ -148,8 +149,16 @@ RUN useradd -u $UID -m -g user -G plugdev user \
 	&& echo 'user ALL = NOPASSWD: ALL' > /etc/sudoers.d/user \
 	&& chmod 0440 /etc/sudoers.d/user
 
+RUN wget ${WGET_ARGS} https://static.rust-lang.org/rustup/rustup-init.sh && \
+	chmod +x rustup-init.sh && \
+	./rustup-init.sh -y && \
+	. $HOME/.cargo/env && \
+	cargo install uefi-run && \
+	rm -f ./rustup-init.sh
+
 # Set the locale
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}
 ENV GNUARMEMB_TOOLCHAIN_PATH=/opt/toolchains/${GCC_ARM_NAME}
 ENV PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
+ENV OVMF_FD_PATH=/usr/share/ovmf/OVMF.fd


### PR DESCRIPTION
we need a test to verify UEFI bootable method in CI, so I added a test https://github.com/zephyrproject-rtos/zephyr/pull/37287 to verify it on qemu_x86_64 platform, but for this test, it needs external environment uefi-run and ovmf, so I added them into CI docker image.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>