### PR TITLE
ci: image: update uefi-run installation path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN wget ${WGET_ARGS} https://static.rust-lang.org/rustup/rustup-init.sh && \
 	chmod +x rustup-init.sh && \
 	./rustup-init.sh -y && \
 	. $HOME/.cargo/env && \
-	cargo install uefi-run && \
+	cargo install uefi-run --root /usr && \
 	rm -f ./rustup-init.sh
 
 # Set the locale


### PR DESCRIPTION
change the installation directory of uefi-run to
/usr/bin, then cmake can find it from system
default path directly.

fix: https://github.com/zephyrproject-rtos/zephyr/issues/37746

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>