### PR TITLE
Satisfy requirements for "tools" building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,11 @@ RUN dpkg --add-architecture i386 && \
 	bison \
 	build-essential \
 	ccache \
+	chrpath \
+	cpio \
 	device-tree-compiler \
 	dfu-util \
+	diffstat \
 	dos2unix \
 	doxygen \
 	file \


### PR DESCRIPTION
Otherwise:
```bash
 $ ./go.sh tools
 ...
 ########################################################################
     Building Zephyr host tools...
 ########################################################################
 MACHINE=qemux86
 ERROR: The following required tools (as specified by HOSTTOOLS) appear to be unavailable in PATH, please install them in order to proceed:
  chrpath cpio diffstat
 Error(s) encountered during bitbake.
```