### PR TITLE
Fix permissions of CMake package path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,8 @@ USER user
 RUN sudo -E -- sh -c ' \
 	wget ${WGET_ARGS} https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}-linux-x86_64-setup.run && \
 	sh "zephyr-sdk-${ZSDK_VERSION}-linux-x86_64-setup.run" --quiet -- -d /opt/toolchains/zephyr-sdk-${ZSDK_VERSION} -y -norc && \
-	rm "zephyr-sdk-${ZSDK_VERSION}-linux-x86_64-setup.run" \
+	rm "zephyr-sdk-${ZSDK_VERSION}-linux-x86_64-setup.run" && \
+	chown -R user:user /home/user/.cmake \
 	'
 
 USER root


### PR DESCRIPTION
Even though the SDK is installed as 'user', the CMake package folder
(/home/user/.cmake) is owned by root due to 'sudo'. Set ownership
explicitely to fix it.
Without the fix, the SDK is not found by west leading to the following error
message:

CMake Error at /home/user/zephyrproject/zephyr/cmake/verify-toolchain.cmake:75 (find_package):
  Could not find a package configuration file provided by "Zephyr-sdk"
  (requested version 0.13.1) with any of the following names:

    Zephyr-sdkConfig.cmake
    zephyr-sdk-config.cmake

  Add the installation prefix of "Zephyr-sdk" to CMAKE_PREFIX_PATH or set
  "Zephyr-sdk_DIR" to a directory containing one of the above files.  If
  "Zephyr-sdk" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  /home/user/zephyrproject/zephyr/cmake/app/boilerplate.cmake:530 (include)
  /home/user/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:24 (include)
  /home/user/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:35 (include_boilerplate)
  CMakeLists.txt:4 (find_package)