### PR TITLE
Dev docker image workdir removal

### DIFF
--- a/Dockerfile.user
+++ b/Dockerfile.user
@@ -30,10 +30,6 @@ ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD ["/bin/bash"]
 USER user
 
-WORKDIR /workdir
-VOLUME ["/workdir"]
-
 
 ARG VNCPASSWD=zephyr
 RUN mkdir ~/.vnc && x11vnc -storepasswd ${VNCPASSWD} ~/.vnc/passwd
-

--- a/README.md
+++ b/README.md
@@ -18,8 +18,23 @@ docker build -f Dockerfile.user --build-arg UID=$(id -u) --build-arg GID=$(id -g
 and can be used for development and building zephyr samples and tests,
 for example:
 
+Clone the zephyr repo:
 ```
-docker run -ti -v <path to zephyr workspace>:/workdir zephyr-build:v<tag>
+git clone git@github.com:zephyrproject-rtos/zephyr.git \
+pushd zephyr; \
+ZEPHYR_SOURCE=$(pwd); \
+popd
+```
+
+Choose a working directory:
+```
+ZEPHYR_WORKDIR=/workdir/zephyr
+```
+
+Run the container:
+
+```
+docker run -ti -w=$ZEPHYR_WORKDIR -v $ZEPHYR_SOURCE:$ZEPHYR_WORKDIR zephyr-build:v<tag>
 ```
 
 Then, follow the steps below to build a sample application:
@@ -76,6 +91,3 @@ For example on a Ubuntu host system:
 ```
 vncviewer localhost:5900
 ```
-
-
-


### PR DESCRIPTION
My use case:
As a developer I'd like to be able to take a fresh install of an operating system, and be able to start developing for zephyr quickly without following the manual steps to setup my local environment on my host OS. To do this I will use the zephyr-build docker image.
Currently this image has a hard coded workdir, which assumes that I have already run west init and west update on my local zephyr source. I'd like to be able to do these steps in the docker container since my local host os doesn't have west.

The problem: 
In the context of running under the container, west update fails because it can't find the submanifests folder, because i've mapped the root of my zephyr source to workdir, it can't find /zephyr/submanifests

Steps taken: 
cloned the zephyr source
run the container with hardcoded /workdir mapped to the root of my cloned zephyr repo
ran `west init -l .`
ran `west update` which fails with:
`FATAL ERROR: Malformed manifest file: /workdir/west.yml 
  Schema file: /usr/local/lib/python3.8/dist-packages/west/manifest-schema.yml
  Hint: /zephyr: "self: import: submanifests": file /zephyr/submanifests not found`

This pull request does three things:
Removes the redundant VOLUME line from the dockerfile (we already specify the volume in the docker run args)
Removes the hard coded workdir from the dockerfile
Updates the readme file to reflect these changes and make no assumptions about the current state of the zephyr source

Signed-off-by: Ryan Hagen <ryan@hagen.tech>