### PR TITLE
Update to Zephyr SDK 0.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certi
 ARG UID=1000
 ARG GID=1000
 
+SHELL ["/bin/bash", "-c"]
+
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN dpkg --add-architecture i386 && \


### PR DESCRIPTION
Install the Zephyr SDK 0.14.0 release.

Note that the Zephyr SDK 0.14.0 is no longer distributed in the self-
extracting archive (SFX) format and is now available as a tarball with
a setup script inside.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>