### PR TITLE
Remove GNU Arm Embedded toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
 ARG ZSDK_VERSION=0.14.0
-ARG GCC_ARM_NAME=gcc-arm-none-eabi-10-2020-q4-major
 ARG CMAKE_VERSION=3.20.5
 ARG RENODE_VERSION=1.12.0
 ARG LLVM_VERSION=12
@@ -112,10 +111,6 @@ RUN pip3 install wheel pip -U &&\
 
 RUN mkdir -p /opt/toolchains
 
-RUN wget ${WGET_ARGS} https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/${GCC_ARM_NAME}-x86_64-linux.tar.bz2  && \
-	tar -xf ${GCC_ARM_NAME}-x86_64-linux.tar.bz2 -C /opt/toolchains/ && \
-	rm -f ${GCC_ARM_NAME}-x86_64-linux.tar.bz2
-
 RUN wget ${WGET_ARGS} https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
 	chmod +x cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
 	./cmake-${CMAKE_VERSION}-Linux-x86_64.sh --skip-license --prefix=/usr/local && \
@@ -173,6 +168,5 @@ USER root
 
 # Set the locale
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-ENV GNUARMEMB_TOOLCHAIN_PATH=/opt/toolchains/${GCC_ARM_NAME}
 ENV PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
 ENV OVMF_FD_PATH=/usr/share/ovmf/OVMF.fd

--- a/README.md
+++ b/README.md
@@ -42,11 +42,8 @@ docker.io/zephyrprojectrtos/zephyr-build:latest
 
 The environment is set and ready to go, no need to source zephyr-env.sh.
 
-We have two toolchains installed:
-- Zephyr SDK
-- GNU Arm Embedded Toolchain
-
-To switch, set ZEPHYR_TOOLCHAIN_VARIANT.
+The Zephyr SDK, which supports building most Zephyr targets, is included in
+both CI and Developer images.
 
 Further it is possible to run _native POSIX_ samples that require a display
 and check the display output via a VNC client. To allow the VNC client to
@@ -76,6 +73,3 @@ For example on a Ubuntu host system:
 ```
 vncviewer localhost:5900
 ```
-
-
-


### PR DESCRIPTION
This commit removes the GNU Arm Embedded toolchain from the CI and
Developer images.

The rationale is as follows:

1. Zephyr SDK now supports all features that the GNU Arm Embedded
   toolchain supports, and it is no longer necessary for the users to
   use this third-party toolchain.

2. The image does not contain any other third-party toolchains and
   there is no reason why the GNU Arm Embedded toolchain needs to be
   special.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>