### PR TITLE
Dockerfile: Install sparse package for code analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,8 @@ RUN apt-get -y update && \
 		valgrind \
 		wget \
 		ovmf \
-		xz-utils
+		xz-utils \
+		sparse
 
 # Install multi-lib gcc (x86 only)
 RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \


### PR DESCRIPTION
The sparse tool can be used to do static code
analysis, which helps to find coding faults
at compile-time.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

The Sound Open Firmware team will need this tool for sparse test and code analysis, which helps to reduce cache coherence issues.