### PR TITLE
Dockerfile: Install sparse package for code analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG CMAKE_VERSION=3.20.5
 ARG RENODE_VERSION=1.13.0
 ARG LLVM_VERSION=12
 ARG BSIM_VERSION=v1.0.3
+ARG SPARSE_VERSION=9212270048c3bd23f56c20a83d4f89b870b2b26e
 ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
 
 ARG UID=1000
@@ -169,6 +170,15 @@ RUN wget ${WGET_ARGS} https://static.rust-lang.org/rustup/rustup-init.sh && \
 RUN wget ${WGET_ARGS} -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
 	apt-get update && \
 	apt-get install -y clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION llvm-$LLVM_VERSION-dev
+
+# Install sparse package for static analysis
+RUN mkdir -p /opt/sparse && \
+	cd /opt/sparse && \
+	git clone https://git.kernel.org/pub/scm/devel/sparse/sparse.git && \
+	cd sparse && git checkout ${SPARSE_VERSION} && \
+	make -j8 && \
+	PREFIX=/opt/sparse make install && \
+	rm -rf /opt/sparse/sparse
 
 # Install Zephyr SDK
 RUN mkdir -p /opt/toolchains && \


### PR DESCRIPTION
The sparse tool can be used to do static code analysis,
which helps to find coding faults at compile-time.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

The Sound Firmware Team will need this package for sparse test. I think zephyr should do sparse test now or sooner.

We have to clone the latest code and compile, the sparse package shipped with ubuntu 20.04 can not work for us.

@lyakh @keqiaozhang FYI