### PR TITLE
ci: Use larger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,6 @@ jobs:
         - 5000:5000
 
     steps:
-    - name: Free up disk space
-      run: |
-        set -x
-
-        # Delete unnecessary files to free up space
-        df -h
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "/usr/local/lib/android"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        df -h
-
     - name: Checkout
       uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-4c
 
     services:
       registry:


### PR DESCRIPTION
This commit updates the CI workflow to use a larger 4-core runner.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>