### PR TITLE
ci: Add workflow for cleaning up stale queued workflow runs

### DIFF
--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -1,0 +1,28 @@
+name: Stale Workflow Queue Cleanup
+
+on:
+  workflow_dispatch:
+    branches: [ master ]
+  schedule:
+    # everyday at 15:00
+  - cron: '0 15 * * *'
+
+concurrency:
+  group: stale-workflow-queue-cleanup
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Delete stale queued workflow runs
+      uses: MajorScruffy/delete-old-workflow-runs@v0.3.0
+      with:
+        repository: ${{ github.repository }}
+        # Remove any workflow runs in "queued" state for more than 1 day
+        older-than-seconds: 86400
+        status: queued
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a workflow to periodically clean-up the stale workflow runs that are stuck in 'queued' state.

These stale workflow runs can result from occasional GitHub webhook delivery mishaps and may affect the CI autoscaler decision making process.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>