### PR TITLE
ci: Use zephyr-runner-linux-x64-xlarge runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04-4c
+    runs-on: zephyr-runner-linux-x64-xlarge
 
     services:
       registry:


### PR DESCRIPTION
This commit updates the CI workflow to use the custom `zephyr-runner-linux-x64-xlarge` runner, which provides 4 vCPUs and 8 GB RAM.

Our custom runners are much more cost effective compared to the runners provided by GitHub.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>