### PR TITLE
base: remove awscli to allow pyocd to work

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -113,7 +113,7 @@ RUN pip3 install wheel pip -U &&\
 	pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt && \
 	pip3 install west &&\
 	pip3 install sh &&\
-	pip3 install awscli PyGithub junitparser pylint \
+	pip3 install PyGithub junitparser pylint \
 		     statistics numpy \
 		     imgtool \
 		     protobuf \


### PR DESCRIPTION
This packages is lagging behind and causing various conflicts. It is
needed for CI in some workflows but not a direct dependency in zephyr.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
