### PR TITLE
Install parallel

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -64,6 +64,7 @@ RUN apt-get -y update && \
 		net-tools \
 		ninja-build \
 		openssh-client \
+		parallel \
 		pkg-config \
 		python3-dev \
 		python3-pip \


### PR DESCRIPTION
We are using for the BT workflow, but it is usefull for developers too.

We can save 10 seconds of CI time per run by not installing it each time.