### PR TITLE
Dockerfile: Upgrade images & deps for Ubuntu 22.04

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,9 +1,6 @@
 # Base Image (ci-base)
 
-FROM ubuntu:20.04
-
-ARG CMAKE_VERSION=3.20.5
-ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
+FROM ubuntu:22.04
 
 ARG UID=1000
 ARG GID=1000
@@ -25,8 +22,10 @@ RUN apt-get -y update && \
 		bison \
 		build-essential \
 		ca-certificates \
+		cargo \
 		ccache \
 		chrpath \
+		cmake \
 		cpio \
 		device-tree-compiler \
 		dfu-util \
@@ -106,17 +105,11 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-# Install CMake
-RUN wget ${WGET_ARGS} https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh && \
-	chmod +x cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh && \
-	./cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh --skip-license --prefix=/usr/local && \
-	rm -f ./cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh
-
 # Install Python dependencies
-RUN python3 -m pip install -U pip && \
-	pip3 install -U wheel setuptools && \
-	pip3 install pygobject && \
-	pip3 install \
+RUN python3 -m pip install -U --no-cache-dir pip && \
+	pip3 install -U --no-cache-dir wheel setuptools && \
+	pip3 install --no-cache-dir pygobject && \
+	pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt \
 		awscli GitPython imgtool junitparser numpy protobuf PyGithub \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -5,13 +5,12 @@ FROM ${BASE_IMAGE:-zephyrprojectrtos/ci-base:latest}
 
 ARG ZSDK_VERSION=0.16.0
 ARG DOXYGEN_VERSION=1.9.4
-ARG CMAKE_VERSION=3.20.5
 ARG RENODE_VERSION=1.13.3
 ARG LLVM_VERSION=15
 ARG BSIM_VERSION=v2.0.1
 ARG SPARSE_VERSION=9212270048c3bd23f56c20a83d4f89b870b2b26e
 ARG PROTOC_VERSION=21.7
-ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
+ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll"
 
 
 # Install Doxygen (x86 only)
@@ -28,11 +27,12 @@ RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
 # NOTE: Renode is currently only available for x86_64 host.
 RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
 	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-	echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
+	echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
 	apt-get -y update && \
 	wget ${WGET_ARGS} https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
 	apt-get install -y ./renode_${RENODE_VERSION}_amd64.deb && \
-	rm renode_${RENODE_VERSION}_amd64.deb \
+	rm renode_${RENODE_VERSION}_amd64.deb && \
+	pip3 install -r /opt/renode/tests/requirements.txt --no-cache-dir \
 	; fi
 
 # Install BSIM
@@ -48,18 +48,31 @@ RUN mkdir -p /opt/bsim && \
 	chmod ag+w . -R
 
 # Install uefi-run utility
-RUN wget ${WGET_ARGS} https://static.rust-lang.org/rustup/rustup-init.sh && \
-	chmod +x rustup-init.sh && \
-	./rustup-init.sh -y && \
-	. $HOME/.cargo/env && \
-	cargo install uefi-run --root /usr && \
-	rm -f ./rustup-init.sh
+RUN cargo install uefi-run --root /usr
 
 # Install LLVM and Clang
-RUN wget ${WGET_ARGS} https://apt.llvm.org/llvm.sh && \
-	chmod +x llvm.sh && \
-	./llvm.sh ${LLVM_VERSION} all && \
-	rm -f llvm.sh
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" | tee /etc/apt/sources.list.d/llvm-official.list && \
+	apt-get -y update && \
+	apt-get -y install \
+		clang-${LLVM_VERSION} \
+		lldb-${LLVM_VERSION} \
+		lld-${LLVM_VERSION} \
+		clangd-${LLVM_VERSION} \
+		clang-tidy-${LLVM_VERSION} \
+		clang-format-${LLVM_VERSION} \
+		clang-tools-${LLVM_VERSION} \
+		llvm-${LLVM_VERSION}-dev \
+		lld-${LLVM_VERSION} \
+		lldb-${LLVM_VERSION} \
+		llvm-${LLVM_VERSION}-tools \
+		libomp-${LLVM_VERSION}-dev \
+		libc++-${LLVM_VERSION}-dev \
+		libc++abi-${LLVM_VERSION}-dev \
+		libclang-common-${LLVM_VERSION}-dev \
+		libclang-${LLVM_VERSION}-dev \
+		libclang-cpp${LLVM_VERSION}-dev \
+		libunwind-${LLVM_VERSION}-dev
 
 # Install sparse package for static analysis
 RUN mkdir -p /opt/sparse && \

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -8,8 +8,8 @@ RUN apt-get -y update && \
 	apt-get -y upgrade && \
 	apt-get install --no-install-recommends -y \
 	openbox \
-	python-xdg \
-	libpython3.8-dev \
+	python3-xdg \
+	libpython3-dev \
 	x11vnc \
 	xvfb \
 	xterm \


### PR DESCRIPTION
Notable dependency changes:

* Use cargo and CMake provided by official Ubuntu repos
   Ubuntu 22.04 comes with CMake 3.22 which satisfies Zephyr's requirement of CMake>3.20
* Use `--no-cache-dir` flag for pip install operations
  Not caching the installation and source files reduces the image's size without any negative side-effects 
* Remove insecure `--no-check-certificate` wget flag
  All wget operations succeed on Ubuntu 22.04 without this flag, and leaving it is asking for supply-chain attacks
* Install renode python requirements
  This follows the official `antmicro/renode` [Dockerfile](https://github.com/RenodeBot/renode-docker/blob/master/Dockerfile) steps
* Install llvm/clang manually
  The `llvm.sh` autoinstaller fails on Ubuntu 22.04 with some cryptic internal package conflicts.
  Running the essential commands manually works fine, so I've adapted these from the install script.

closes: #105