### PR TITLE
Dockerfile: Install LLVM 15 from Ubuntu repository

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -51,9 +51,7 @@ RUN mkdir -p /opt/bsim && \
 RUN cargo install uefi-run --root /usr
 
 # Install LLVM and Clang
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" | tee /etc/apt/sources.list.d/llvm-official.list && \
-	apt-get -y update && \
+RUN apt-get -y update && \
 	apt-get -y install \
 		clang-${LLVM_VERSION} \
 		lldb-${LLVM_VERSION} \


### PR DESCRIPTION
Use LLVM/clang provided by the jammy-updates repository instead of apt.llvm.org

fixes: #144