### PR TITLE
Dockerfile: Remove awscli Python package

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -112,7 +112,7 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 	pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt \
-		awscli GitPython imgtool junitparser numpy protobuf PyGithub \
+		GitPython imgtool junitparser numpy protobuf PyGithub \
 		pylint sh statistics west && \
 	pip3 check
 


### PR DESCRIPTION
This commit removes the `awscli` Python package from the base CI image because it is not currently not used by any Zephyr CI workflows and has `PyYAML` dependency conflict with the Renode (see the GH issue #145).

If the AWS command line tool is necessary in the future, look into either migrating to the `awscliv2` or installing the `awscli` package in a virtual environment.

---

Fixes #145