### PR TITLE
ci: Disable LLVM 16 installation for AArch64 image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -51,10 +51,14 @@ RUN mkdir -p /opt/bsim_west && \
 RUN cargo install uefi-run --root /usr
 
 # Install LLVM and Clang
-RUN wget ${WGET_ARGS} https://apt.llvm.org/llvm.sh && \
+# FIXME: AArch64 is disabled because the LLVM APT repository contains broken
+#        packages for it.
+RUN if [ "${HOSTTYPE}" != "aarch64" ]; then \
+	wget ${WGET_ARGS} https://apt.llvm.org/llvm.sh && \
 	chmod +x llvm.sh && \
 	./llvm.sh ${LLVM_VERSION} all && \
-	rm -f llvm.sh
+	rm -f llvm.sh \
+	; fi
 
 # Install sparse package for static analysis
 RUN mkdir -p /opt/sparse && \


### PR DESCRIPTION
This commit disables the LLVM 16 installation for the AArch64 CI Docker image because the LLVM APT repository currently contains broken packages for the AArch64 architecture (note that the x86-64 architecture is not affected).

Revert this commit when this issue is fixed in the LLVM APT repository.