### PR TITLE
.github: workflows: Trigger on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,13 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
     - v*-branch
     tags:
     - v*
   pull_request:
     branches:
-    - master
+    - main
     - v*-branch
 
 permissions:

--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -2,7 +2,7 @@ name: Stale Workflow Queue Cleanup
 
 on:
   workflow_dispatch:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     # everyday at 15:00
   - cron: '0 15 * * *'


### PR DESCRIPTION
With the renaming of the `master` branch to `main`, this commit updates the CI workflows to trigger on the `main` branch instead of the `master` branch.