### PR TITLE
base: Use main branch to source Python requirements

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -111,7 +111,7 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 	pip3 install --no-cache-dir pygobject && \
 	pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
-		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt \
+		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
 		GitPython imgtool junitparser numpy protobuf PyGithub \
 		pylint sh statistics west && \
 	pip3 check

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -110,7 +110,7 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 	pip3 install -U --no-cache-dir wheel setuptools && \
 	pip3 install --no-cache-dir pygobject && \
 	pip3 install --no-cache-dir \
-		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt \
+		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt \
 		GitPython imgtool junitparser numpy protobuf PyGithub \
 		pylint sh statistics west && \


### PR DESCRIPTION
This series upates the base image Dockerfile to source the Python package requirements from the `main` branch instead of the `master` branch of the relevant repositories.