### PR TITLE
Base: Install also libfuse-dev:i386 on x86-64

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -95,7 +95,7 @@ RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
 	apt-get -y update && \
 	apt-get -y upgrade && \
 	apt-get install --no-install-recommends -y \
-		libsdl2-dev:i386 \
+		libsdl2-dev:i386 libfuse-dev:i386 \
 	; fi
 
 # Initialise system locale


### PR DESCRIPTION
So we can build the native host FUSE access to flash