### PR TITLE
base: Add GDB

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -37,6 +37,7 @@ RUN apt-get -y update && \
 		gawk \
 		gcc \
 		gcovr \
+		gdb \
 		git \
 		git-core \
 		gnupg \


### PR DESCRIPTION
Native boards currently cannot be debugged with `west debug` in the docker images. This PR add GDB to enable debugging for said boards.  