### PR TITLE
base: Add nrf-regtool to the list of Python packages installed

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -113,7 +113,8 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
 		GitPython imgtool junitparser numpy protobuf PyGithub \
-		pylint sh statistics west && \
+		pylint sh statistics west \
+		nrf-regtool && \
 	pip3 check
 
 # Clean up stale packages


### PR DESCRIPTION
After a discussion in Discord
(https://discord.com/channels/720317445772017664/1196766845332619305/1196766847962464276) we concluded that there is no easy way of adding vendor-specific Python packages that are required to be executed during the build but should not be present in the standard requirements-*.txt files since they are specific to a single vendor.

For now solve the issue by including the package by name in the Docker file, to have the package available for the PR that introduced the first IC that requires this package, the nRF54H20 (https://github.com/zephyrproject-rtos/zephyr/pull/68043).