### PR TITLE
base: Require nrf-regtool version 5.1.0 or above

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -114,7 +114,7 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
 		GitPython imgtool junitparser numpy protobuf PyGithub \
 		pylint sh statistics west \
-		nrf-regtool && \
+		nrf-regtool>=5.1.0 && \
 	pip3 check
 
 # Clean up stale packages


### PR DESCRIPTION
This commit updates the base image Dockerfile to include nrf-regtool version 5.1.0 or above.