### PR TITLE
.github: workflows: Use zephyr-runner v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,20 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DOCKERHUB_BASE: docker.io/zephyrprojectrtos
+  GHCR_BASE: ghcr.io/zephyrproject-rtos
+  BASE_IMAGE_NAME: ci-base
+  CI_IMAGE_NAME: ci
+  DEVELOPER_IMAGE_NAME: zephyr-build
+
 jobs:
   build:
     name: Build (${{ matrix.variant.platform }})
-    runs-on: ${{ matrix.variant.builder }}
+    runs-on:
+      group: ${{ matrix.variant.builder }}
+    container:
+      image: ghcr.io/zephyrproject-rtos/image-build:v1.0.0
 
     strategy:
       fail-fast: true
@@ -30,191 +40,155 @@ jobs:
         variant:
         - platform: linux/amd64
           arch: amd64
-          builder: zephyr-runner-linux-x64-4xlarge
+          builder: zephyr-runner-v2-linux-x64-4xlarge
         - platform: linux/arm64
           arch: arm64
-          builder: zephyr-runner-linux-arm64-4xlarge
-
-    services:
-      registry:
-        image: registry:2
-        ports:
-        - 5000:5000
+          builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Generate local metadata for base image
-      id: meta_ci_base
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          localhost:5000/zephyrproject-rtos/ci-base
-
-    - name: Generate local metadata for CI image
-      id: meta_ci
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          localhost:5000/zephyrproject-rtos/ci
-
-    - name: Generate local metadata for Developer image
-      id: meta_developer
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          localhost:5000/zephyrproject-rtos/zephyr-build
-
-    - name: Generate push metadata for base image
-      if: ${{ github.event_name != 'pull_request' }}
-      id: meta_ci_base_push
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          docker.io/zephyrprojectrtos/ci-base
-          ghcr.io/zephyrproject-rtos/ci-base
-        flavor: |
-          latest=false
-          suffix=-${{ matrix.variant.arch }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-
-    - name: Generate push metadata for CI image
-      if: ${{ github.event_name != 'pull_request' }}
-      id: meta_ci_push
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          docker.io/zephyrprojectrtos/ci
-          ghcr.io/zephyrproject-rtos/ci
-        flavor: |
-          latest=false
-          suffix=-${{ matrix.variant.arch }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-
-    - name: Generate push metadata for Developer image
-      if: ${{ github.event_name != 'pull_request' }}
-      id: meta_developer_push
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          docker.io/zephyrprojectrtos/zephyr-build
-          ghcr.io/zephyrproject-rtos/zephyr-build
-        flavor: |
-          latest=false
-          suffix=-${{ matrix.variant.arch }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        driver-opts: network=host
-
-    - name: Build base docker image
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: Dockerfile.base
-        platforms: ${{ matrix.variant.platform }}
-        push: true
-        tags: ${{ steps.meta_ci_base.outputs.tags }}
-        labels: ${{ steps.meta_ci_base.outputs.labels }}
-
-    - name: Build CI docker image
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: Dockerfile.ci
-        platforms: ${{ matrix.variant.platform }}
-        push: true
-        tags: ${{ steps.meta_ci.outputs.tags }}
-        labels: ${{ steps.meta_ci.outputs.labels }}
-        build-args: |
-          BASE_IMAGE=localhost:5000/zephyrproject-rtos/ci-base:${{ steps.meta_ci_base.outputs.version }}
-
-    - name: Build Developer docker image
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: Dockerfile.devel
-        platforms: ${{ matrix.variant.platform }}
-        push: true
-        tags: ${{ steps.meta_developer.outputs.tags }}
-        labels: ${{ steps.meta_developer.outputs.labels }}
-        build-args: |
-          BASE_IMAGE=localhost:5000/zephyrproject-rtos/ci:${{ steps.meta_ci.outputs.version }}
+      uses: actions/checkout@v4
 
     - name: Login to DockerHub
       if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v2
+      uses: redhat-actions/podman-login@v1
       with:
         registry: docker.io
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to GitHub Container Registry
       if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v2
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push base docker image
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: stephanosio/tag-push-action@v2.1.0
+    - name: Generate metadata for base image
+      id: meta_base
+      uses: docker/metadata-action@v5
       with:
-        src: localhost:5000/zephyrproject-rtos/ci-base:${{ steps.meta_ci_base.outputs.version }}
-        dst: ${{ steps.meta_ci_base_push.outputs.tags }}
+        images: |
+          ${{ env.DOCKERHUB_BASE }}/${{ env.BASE_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.BASE_IMAGE_NAME }}
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.variant.arch }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
 
-    - name: Push CI docker image
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: stephanosio/tag-push-action@v2.1.0
+    - name: Generate metadata for CI image
+      id: meta_ci
+      uses: docker/metadata-action@v5
       with:
-        src: localhost:5000/zephyrproject-rtos/ci:${{ steps.meta_ci.outputs.version }}
-        dst: ${{ steps.meta_ci_push.outputs.tags }}
+        images: |
+          ${{ env.DOCKERHUB_BASE }}/${{ env.CI_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.CI_IMAGE_NAME }}
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.variant.arch }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
 
-    - name: Push Developer docker image
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: stephanosio/tag-push-action@v2.1.0
+    - name: Generate metadata for Developer image
+      id: meta_developer
+      uses: docker/metadata-action@v5
       with:
-        src: localhost:5000/zephyrproject-rtos/zephyr-build:${{ steps.meta_developer.outputs.version }}
-        dst: ${{ steps.meta_developer_push.outputs.tags }}
+        images: |
+          ${{ env.DOCKERHUB_BASE }}/${{ env.DEVELOPER_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.DEVELOPER_IMAGE_NAME }}
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.variant.arch }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+
+    - name: Build base image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        context: .
+        containerfiles: Dockerfile.base
+        tags: ${{ steps.meta_base.outputs.tags }}
+        labels: ${{ steps.meta_base.outputs.labels }}
+
+    - name: Build CI image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        context: .
+        containerfiles: Dockerfile.ci
+        tags: ${{ steps.meta_ci.outputs.tags }}
+        labels: ${{ steps.meta_ci.outputs.labels }}
+        build-args: |
+          BASE_IMAGE=${{ env.GHCR_BASE }}/${{ env.BASE_IMAGE_NAME }}:${{ steps.meta_base.outputs.version }}
+
+    - name: Build Developer image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        context: .
+        containerfiles: Dockerfile.devel
+        tags: ${{ steps.meta_developer.outputs.tags }}
+        labels: ${{ steps.meta_developer.outputs.labels }}
+        build-args: |
+          BASE_IMAGE=${{ env.GHCR_BASE }}/${{ env.CI_IMAGE_NAME }}:${{ steps.meta_ci.outputs.version }}
+
+    - name: Push base image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.meta_base.outputs.tags }}
+
+    - name: Push CI image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.meta_ci.outputs.tags }}
+
+    - name: Push Developer image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.meta_developer.outputs.tags }}
 
   merge:
     name: Merge
-    runs-on: zephyr-runner-linux-x64-4xlarge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/image-build:v1.0.0
     needs: build
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/podman-login@v1
       with:
         registry: docker.io
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Generate push metadata for base docker image
-      id: meta_ci_base_push
-      uses: docker/metadata-action@v4
+    - name: Generate metadata for base image
+      id: meta_base
+      uses: docker/metadata-action@v5
       with:
         images: |
-          docker.io/zephyrprojectrtos/ci-base
-          ghcr.io/zephyrproject-rtos/ci-base
+          ${{ env.DOCKERHUB_BASE }}/${{ env.BASE_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.BASE_IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |
@@ -222,13 +196,13 @@ jobs:
           type=ref,event=tag
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Generate push metadata for CI image
-      id: meta_ci_push
-      uses: docker/metadata-action@v4
+    - name: Generate metadata for CI image
+      id: meta_ci
+      uses: docker/metadata-action@v5
       with:
         images: |
-          docker.io/zephyrprojectrtos/ci
-          ghcr.io/zephyrproject-rtos/ci
+          ${{ env.DOCKERHUB_BASE }}/${{ env.CI_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.CI_IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |
@@ -236,13 +210,13 @@ jobs:
           type=ref,event=tag
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Generate push metadata for Developer image
-      id: meta_developer_push
-      uses: docker/metadata-action@v4
+    - name: Generate metadata for Developer image
+      id: meta_developer
+      uses: docker/metadata-action@v5
       with:
         images: |
-          docker.io/zephyrprojectrtos/zephyr-build
-          ghcr.io/zephyrproject-rtos/zephyr-build
+          ${{ env.DOCKERHUB_BASE }}/${{ env.DEVELOPER_IMAGE_NAME }}
+          ${{ env.GHCR_BASE }}/${{ env.DEVELOPER_IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |
@@ -253,46 +227,59 @@ jobs:
     - name: Create multi-architecture image
       run: |
         archs=(amd64 arm64)
-        ci_base_image="ghcr.io/zephyrproject-rtos/ci-base:${{ steps.meta_ci_base_push.outputs.version }}"
-        ci_image="ghcr.io/zephyrproject-rtos/ci:${{ steps.meta_ci_push.outputs.version }}"
-        developer_image="ghcr.io/zephyrproject-rtos/zephyr-build:${{ steps.meta_developer_push.outputs.version }}"
 
-        # Pull architecture-specific images
+        base_image="${{ env.GHCR_BASE }}/${{ env.BASE_IMAGE_NAME }}:${{ steps.meta_base.outputs.version }}"
+        ci_image="${{ env.GHCR_BASE }}/${{ env.CI_IMAGE_NAME }}:${{ steps.meta_ci.outputs.version }}"
+        developer_image="${{ env.GHCR_BASE }}/${{ env.DEVELOPER_IMAGE_NAME }}:${{ steps.meta_developer.outputs.version }}"
+
+        base_image_tags="${{ steps.meta_base.outputs.tags }}"
+        ci_image_tags="${{ steps.meta_ci.outputs.tags }}"
+        developer_image_tags="${{ steps.meta_developer.outputs.tags }}"
+
+        # Pull architecture-specific images.
         for arch in ${archs[@]}; do
-          docker pull ${ci_base_image}-${arch}
-          docker pull ${ci_image}-${arch}
-          docker pull ${developer_image}-${arch}
+          podman pull ${base_image}-${arch}
+          podman pull ${ci_image}-${arch}
+          podman pull ${developer_image}-${arch}
         done
 
-        # Create multi-architecture image
+        # Create multi-architecture images.
         for arch in ${archs[@]}; do
-          ci_base_image_amend_flags+="--amend ${ci_base_image}-${arch} "
+          base_image_amend_flags+="--amend ${base_image}-${arch} "
           ci_image_amend_flags+="--amend ${ci_image}-${arch} "
           developer_image_amend_flags+="--amend ${developer_image}-${arch} "
         done
 
-        docker manifest create ${ci_base_image} ${ci_base_image_amend_flags}
-        docker manifest create ${ci_image} ${ci_image_amend_flags}
-        docker manifest create ${developer_image} ${developer_image_amend_flags}
+        podman manifest create ${base_image} ${base_image_amend_flags}
+        podman manifest create ${ci_image} ${ci_image_amend_flags}
+        podman manifest create ${developer_image} ${developer_image_amend_flags}
 
-        docker manifest push ${ci_base_image}
-        docker manifest push ${ci_image}
-        docker manifest push ${developer_image}
+        # Create base image tags.
+        for tag in ${base_image_tags}; do
+          podman tag ${base_image} ${tag}
+        done
 
-    - name: Push base docker image
-      uses: stephanosio/tag-push-action@v2.1.0
+        # Create CI image tags.
+        for tag in ${ci_image_tags}; do
+          podman tag ${ci_image} ${tag}
+        done
+
+        # Create developer image tags.
+        for tag in ${developer_image_tags}; do
+          podman tag ${developer_image} ${tag}
+        done
+
+    - name: Push base image
+      uses: redhat-actions/push-to-registry@v2
       with:
-        src: ghcr.io/zephyrproject-rtos/ci-base:${{ steps.meta_ci_base_push.outputs.version }}
-        dst: ${{ steps.meta_ci_base_push.outputs.tags }}
+        tags: ${{ steps.meta_base.outputs.tags }}
 
-    - name: Push CI docker image
-      uses: stephanosio/tag-push-action@v2.1.0
+    - name: Push CI image
+      uses: redhat-actions/push-to-registry@v2
       with:
-        src: ghcr.io/zephyrproject-rtos/ci:${{ steps.meta_ci_push.outputs.version }}
-        dst: ${{ steps.meta_ci_push.outputs.tags }}
+        tags: ${{ steps.meta_ci.outputs.tags }}
 
-    - name: Push Developer docker image
-      uses: stephanosio/tag-push-action@v2.1.0
+    - name: Push Developer image
+      uses: redhat-actions/push-to-registry@v2
       with:
-        src: ghcr.io/zephyrproject-rtos/zephyr-build:${{ steps.meta_developer_push.outputs.version }}
-        dst: ${{ steps.meta_developer_push.outputs.tags }}
+        tags: ${{ steps.meta_developer.outputs.tags }}


### PR DESCRIPTION
This commit updates the CI workflow to use the new zephyr-runner v2.

As part of this, it also reworks the workflow to use Buildah and Podman, which is daemon-less and does not require root privileges, to build Docker images because the new runners have more strict security requirements and run workflow pods in unprivileged mode, which effectively makes it impossible to run Docker daemon inside a runner.