### PR TITLE
.github: workflows: Ensure that local base images are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
+    - name: Configure temporary directory
+      run: |
+        mkdir -p /__w/tmp
+        echo "TMPDIR=/__w/tmp" >> $GITHUB_ENV
+
     - name: Configure container storage
       run: |
         sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf
@@ -175,6 +180,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Configure temporary directory
+      run: |
+        mkdir -p /__w/tmp
+        echo "TMPDIR=/__w/tmp" >> $GITHUB_ENV
+
     - name: Configure container storage
       run: |
         sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Configure container storage
+      run: |
+        sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf
+        mkdir -p /__w/container_storage
+
     - name: Login to DockerHub
       if: ${{ github.event_name != 'pull_request' }}
       uses: redhat-actions/podman-login@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
         labels: ${{ steps.meta_ci.outputs.labels }}
         build-args: |
           BASE_IMAGE=${{ env.GHCR_BASE }}/${{ env.BASE_IMAGE_NAME }}:${{ steps.meta_base.outputs.version }}
+        extra-args: |
+          --pull-never
 
     - name: Build Developer image
       uses: redhat-actions/buildah-build@v2
@@ -142,6 +144,8 @@ jobs:
         labels: ${{ steps.meta_developer.outputs.labels }}
         build-args: |
           BASE_IMAGE=${{ env.GHCR_BASE }}/${{ env.CI_IMAGE_NAME }}:${{ steps.meta_ci.outputs.version }}
+        extra-args: |
+          --pull-never
 
     - name: Push base image
       if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This commit adds the `--pull-never` flag to the derivative image builds
in order to ensure that the locally built base image is used instead of
a remote pulled one.

Without this flag, buildah may pull the remote tag even if a local copy
with the same tag name exists.