### PR TITLE
base: Add junit2html

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -112,7 +112,7 @@ RUN python3 -m pip install -U --no-cache-dir pip && \
 	pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
-		GitPython imgtool junitparser numpy protobuf PyGithub \
+		GitPython imgtool junitparser junit2html numpy protobuf PyGithub \
 		pylint sh statistics west \
 		nrf-regtool>=5.3.0 && \
 	pip3 check


### PR DESCRIPTION
We are using junit2html in the CI jobs.
Let's install it in the image to save a bit of time.