### PR TITLE
ci: Add rust target support

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -89,6 +89,17 @@ RUN wget -q -O-  "https://sh.rustup.rs" | sh -s -- -y
 # Install uefi-run utility
 RUN ~/.cargo/bin/cargo install uefi-run --root /usr
 
+# Install target support for Rust.  This is the list as of the current
+# time.
+RUN \
+	~/.cargo/bin/rustup target install riscv32i-unknown-none-elf && \
+	~/.cargo/bin/rustup target install riscv64imac-unknown-none-elf && \
+	~/.cargo/bin/rustup target install thumbv6m-none-eabi && \
+	~/.cargo/bin/rustup target install thumbv7em-none-eabi && \
+	~/.cargo/bin/rustup target install thumbv7m-none-eabi && \
+	~/.cargo/bin/rustup target install thumbv8m.main-none-eabi && \
+	~/.cargo/bin/rustup target install x86_64-unknown-none
+
 # Install LLVM and Clang
 RUN wget ${WGET_ARGS} https://apt.llvm.org/llvm.sh && \
 	chmod +x llvm.sh && \


### PR DESCRIPTION
Invoke `rust target add ...` for each of the targets supported by Zephyr.  There is a bit of a catch-22 here.  We should be getting this list from the build, but the change that adds Rust support can't merge until Rust support has been tested.

Once the first PR is merged, and the zephyr/lib/rust/targets.txt file exists, the hardcoded list here can be replaced by a loop that adds each of these targest.

All of the targets adds about 300Mb to the image, as these targets only include a fairly minimal 'core' and 'alloc' library.