### PR TITLE
base: Install libc6-dbg:i386

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -96,7 +96,7 @@ RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
 	apt-get -y update && \
 	apt-get -y upgrade && \
 	apt-get install --no-install-recommends -y \
-		libsdl2-dev:i386 libfuse-dev:i386 \
+		libsdl2-dev:i386 libfuse-dev:i386 libc6-dbg:i386 \
 	; fi
 
 # Initialise system locale


### PR DESCRIPTION
In tests, users may see a segfault in CI which they may not be able to reproduce locally (due to having a different OS).
A user may try to get more info in CI by running that test with valgrind. But for valgrind to run with 32bit targets we need libc6-dbg:i386 installed.
So let's install it by default so it is ready for users.