### PR TITLE
README: Add notes about Zephyr 3.7 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,38 @@ building most Zephyr targets.
 The pre-built developer docker image is available on both GitHub Container Registry (`ghcr.io`) and
 DockerHub (`docker.io`).
 
-**GitHub Container Registry (`ghcr.io`)**
+For Zephyr 3.7 LTS, use the `v0.26-branch` or the latest `v0.26.x` release Docker image.
+
+##### GitHub Container Registry (`ghcr.io`)
+
+###### Current Zephyr versions
 
 ```
 docker run -ti -v $HOME/Work/zephyrproject:/workdir \
            ghcr.io/zephyrproject-rtos/zephyr-build:main
 ```
 
-**DockerHub (`docker.io`)**
+###### Zephyr 3.7 LTS
+
+```
+docker run -ti -v $HOME/Work/zephyrproject:/workdir \
+           ghcr.io/zephyrproject-rtos/zephyr-build:v0.26-branch
+```
+
+##### DockerHub (`docker.io`)
+
+###### Current Zephyr versions
 
 ```
 docker run -ti -v $HOME/Work/zephyrproject:/workdir \
            docker.io/zephyrprojectrtos/zephyr-build:main
+```
+
+###### Zephyr 3.7 LTS
+
+```
+docker run -ti -v $HOME/Work/zephyrproject:/workdir \
+           docker.io/zephyrprojectrtos/zephyr-build:v0.26-branch
 ```
 
 #### Building Developer Docker Image

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ DockerHub (`docker.io`).
 
 ```
 docker run -ti -v $HOME/Work/zephyrproject:/workdir \
-           ghcr.io/zephyrproject-rtos/zephyr-build:latest
+           ghcr.io/zephyrproject-rtos/zephyr-build:main
 ```
 
 **DockerHub (`docker.io`)**
 
 ```
 docker run -ti -v $HOME/Work/zephyrproject:/workdir \
-           docker.io/zephyrprojectrtos/zephyr-build:latest
+           docker.io/zephyrprojectrtos/zephyr-build:main
 ```
 
 #### Building Developer Docker Image


### PR DESCRIPTION
This commit adds notes about retrieving the correct version of Docker
image for the Zephyr 3.7 LTS.