### PR TITLE
Add USERNAME build argument

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,6 +2,7 @@
 
 FROM ubuntu:24.04
 
+ARG USERNAME=user
 ARG UID=1000
 ARG GID=1000
 ARG PYTHON_VENV_PATH=/opt/python/venv
@@ -134,10 +135,10 @@ RUN apt-get clean -y && \
 	rm -rf /var/lib/apt/lists/*
 
 # Create 'user' account
-RUN groupadd -g $GID -o user
+RUN groupadd -g $GID -o $USERNAME
 
-RUN useradd -u $UID -m -g user -G plugdev user \
-	&& echo 'user ALL = NOPASSWD: ALL' > /etc/sudoers.d/user \
-	&& chmod 0440 /etc/sudoers.d/user
+RUN useradd -u $UID -m -g $USERNAME -G plugdev $USERNAME \
+	&& echo $USERNAME ' ALL = NOPASSWD: ALL' > /etc/sudoers.d/$USERNAME \
+	&& chmod 0440 /etc/sudoers.d/$USERNAME
 
 USER root

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,6 +3,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE:-zephyrprojectrtos/ci-base:latest}
 
+ARG USERNAME=user
 ARG ZSDK_VERSION=0.17.1
 ENV ZSDK_VERSION=$ZSDK_VERSION
 ARG KITWARE_NINJA_VERSION=1.11.1.g95dee.kitware.jobserver-1
@@ -184,11 +185,11 @@ RUN apt-get clean -y && \
 # Run the Zephyr SDK setup script as 'user' in order to ensure that the
 # `Zephyr-sdk` CMake package is located in the package registry under the
 # user's home directory.
-USER user
+USER $USERNAME
 
 RUN sudo -E -- bash -c ' \
 	/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}/setup.sh -c && \
-	chown -R user:user /home/user/.cmake \
+	chown -R $USERNAME:$USERNAME /home/$USERNAME/.cmake \
 	'
 
 USER root

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -3,6 +3,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE:-zephyrprojectrtos/ci:latest}
 
+ARG USERNAME=user
+
 # Install packages
 RUN apt-get -y update && \
 	apt-get -y upgrade && \
@@ -13,24 +15,33 @@ RUN apt-get -y update && \
 	x11vnc \
 	xvfb \
 	xterm \
-	xz-utils
+	xz-utils \
+	usbutils \
+	vim
 
 # Clean up stale packages
 RUN apt-get clean -y && \
 	apt-get autoremove --purge -y && \
 	rm -rf /var/lib/apt/lists/*
 
-# Add entrypoint script
-ADD ./entrypoint.sh /home/user/entrypoint.sh
-RUN dos2unix /home/user/entrypoint.sh
-ENTRYPOINT ["/home/user/entrypoint.sh"]
+# Add entrypoint script (it is in home because
+# I can't figure out how to get the $USERNAME
+# into the string.)
+ADD ./entrypoint.sh /home/entrypoint.sh
+RUN dos2unix /home/entrypoint.sh
+ENTRYPOINT ["/home/entrypoint.sh"]
 
 # Add bash completion script
-ADD ./bash_completion /home/user/.bash_completion
-RUN mkdir -p /home/user/.bash_completion.d
+ADD ./bash_completion /home/$USERNAME/.bash_completion
+RUN mkdir -p /home/$USERNAME/.bash_completion.d
+
+
+# Adjust $USERNAME home directory permissions
+USER root
+RUN chown -R $USERNAME:$USERNAME /home/$USERNAME
 
 # Switch to 'user' context
-USER user
+USER $USERNAME
 
 # Configure environment variables
 ENV DISPLAY=:0
@@ -46,13 +57,6 @@ RUN mkdir ~/.vnc && x11vnc -storepasswd ${VNCPASSWD} ~/.vnc/passwd
 
 # Expose port 5900 for VNC
 EXPOSE 5900
-
-# Adjust 'user' home directory permissions
-USER root
-RUN chown -R user:user /home/user
-
-# Make 'user' default on launch
-USER user
 
 # Launch bash shell by default
 CMD ["/bin/bash"]


### PR DESCRIPTION
Adding a USERNAME build argument so that the ssh-agents will work (they require the username inside the container to be the same as the user name that is running the ssh-agent.  This is an optional argument so if they don't use it, it defaults to `user` as before.

I ran into a problem with getting the entrypoint.sh path to work with the ${USERNAME} variable so I just punted and put the entrypoint.sh in the `/user` directory.  If anyone knows how to get it to work, please speak up :)