### PR TITLE
fix: pin pygobject pip package to 3.50.0

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,6 +47,7 @@ RUN apt-get -y update && \
 		iproute2 \
 		lcov \
 		libcairo2-dev \
+		libgirepository1.0-dev \
 		libglib2.0-dev \
 		libgtk2.0-0 \
 		liblocale-gettext-perl \
@@ -108,7 +109,7 @@ ENV LC_ALL=en_US.UTF-8
 # Install Python dependencies
 RUN python3 -m pip install -U --no-cache-dir pip && \
 	pip3 install -U --no-cache-dir wheel setuptools && \
-	pip3 install --no-cache-dir pygobject && \
+	pip3 install --no-cache-dir pygobject==v3.50.0 && \
 	pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \


### PR DESCRIPTION
Versions of pygobject from 3.51.0 forward require
libgirepository-2.0-dev as a dependency, but that one is not yet available on the Ubuntu 22.04 (it is on 24.04).

3.50.0 version requires libgirepository-1.0-dev, which is available on the Ubuntu 22.04, however that package was never explicitly installed, so this commit also adds it.

By pinning the pip package and adding new apt package we ensure that Dockerfile.base can be even built.

Closes: #222