### PR TITLE
Specificy explict rust version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -88,7 +88,7 @@ RUN mkdir -p /opt/bsim_west && \
 	ln -s /opt/bsim_west/bsim /opt/bsim
 
 # Install cargo environment
-RUN wget -q -O-  "https://sh.rustup.rs" | sh -s -- -y
+RUN wget -q -O-  "https://sh.rustup.rs" | sh -s -- -y --default-toolchain 1.86
 
 # Install uefi-run utility
 RUN ~/.cargo/bin/cargo install uefi-run --root /usr


### PR DESCRIPTION
By default, rustup installs the "latest" stable version of the rust toolchain.  Instead, fix this to a specific version.  This serves two purposes:

- It becomes possible to map a docker image version to a specific version of the rust toolchain that it contains.
- It makes upgrades explicit, especially when features of a specific version are needed.

This sets the version to the current stable version: 1.86.