### PR TITLE
base: Install grpcio-tools

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -120,7 +120,7 @@ RUN cd ${PYTHON_VENV_PATH}/bin && \
 RUN pip3 install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
-		GitPython imgtool junitparser junit2html numpy protobuf PyGithub \
+		GitPython imgtool junitparser junit2html numpy protobuf grpcio-tools PyGithub \
 		pylint sh statistics west \
 		nrf-regtool~=9.0.1
 # Run pip check on x86 only for now, it fails on arm.

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -56,7 +56,7 @@ RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
 # Install Doxygen (x86 only)
 # NOTE: Pre-built Doxygen binaries are only available for x86_64 host.
 RUN if [ "${HOSTTYPE}" = "x86_64" ]; then \
-	wget ${WGET_ARGS} https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz && \
+	wget ${WGET_ARGS} "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" && \
 	tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt && \
 	ln -s /opt/doxygen-${DOXYGEN_VERSION}/bin/doxygen /usr/local/bin && \
 	rm doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz \


### PR DESCRIPTION
Make sure grpcio-tools is installed to have protoc compiler in python.