### PR TITLE
Use Hetzner Ubuntu mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
         containerfiles: Dockerfile.base
         tags: ${{ steps.meta_base.outputs.tags }}
         labels: ${{ steps.meta_base.outputs.labels }}
+        build-args: |
+          UBUNTU_MIRROR_ARCHIVE=mirror.hetzner.com/ubuntu/packages
+          UBUNTU_MIRROR_SECURITY=mirror.hetzner.com/ubuntu/security
+          UBUNTU_MIRROR_PORTS=mirror.hetzner.com/ubuntu-ports/packages
 
     - name: Build CI image
       uses: redhat-actions/buildah-build@v2

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,6 +6,9 @@ ARG USERNAME=user
 ARG UID=1000
 ARG GID=1000
 ARG PYTHON_VENV_PATH=/opt/python/venv
+ARG UBUNTU_MIRROR_ARCHIVE=archive.ubuntu.com/ubuntu
+ARG UBUNTU_MIRROR_SECURITY=security.ubuntu.com/ubuntu
+ARG UBUNTU_MIRROR_PORTS=ports.ubuntu.com/ubuntu-ports
 
 # this conflicts with uid 1000, remove it
 RUN userdel -r ubuntu || true
@@ -15,6 +18,11 @@ SHELL ["/bin/bash", "-c"]
 
 # Set non-interactive frontend for apt-get to skip any user confirmations
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Set up Ubuntu mirrors
+RUN sed -i "s#archive.ubuntu.com/ubuntu#${UBUNTU_MIRROR_ARCHIVE}#" /etc/apt/sources.list.d/ubuntu.sources && \
+	sed -i "s#security.ubuntu.com/ubuntu#${UBUNTU_MIRROR_SECURITY}#" /etc/apt/sources.list.d/ubuntu.sources && \
+	sed -i "s#ports.ubuntu.com/ubuntu-ports#${UBUNTU_MIRROR_PORTS}#" /etc/apt/sources.list.d/ubuntu.sources
 
 # Install base packages
 RUN apt-get -y update && \


### PR DESCRIPTION
Use Hetzner Ubuntu mirror because the official mirror currently throttles package downloads and causes the Docker image builds to frequently fail.