### PR TITLE
.github: workflows: Use Hetzner Ubuntu mirror on Hetzner runners only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
     steps:
     - name: Print cloud service information
       run: |
-	echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
-	echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
-	echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+        echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+        echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+        echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
 
     - name: Configure temporary directory
       run: |
@@ -126,6 +126,19 @@ jobs:
           type=ref,event=tag
           type=ref,event=pr
 
+    - name: Generate base image build arguments
+      id: buildarg_base
+      run: |
+        {
+          echo "args<<EOF"
+          if [ "${ZEPHYR_RUNNER_CLOUD_PROVIDER}" == "Hetzner" ]; then
+            echo "UBUNTU_MIRROR_ARCHIVE=mirror.hetzner.com/ubuntu/packages"
+            echo "UBUNTU_MIRROR_SECURITY=mirror.hetzner.com/ubuntu/security"
+            echo "UBUNTU_MIRROR_PORTS=mirror.hetzner.com/ubuntu-ports/packages"
+          fi
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
+
     - name: Build base image
       uses: redhat-actions/buildah-build@v2
       with:
@@ -133,10 +146,7 @@ jobs:
         containerfiles: Dockerfile.base
         tags: ${{ steps.meta_base.outputs.tags }}
         labels: ${{ steps.meta_base.outputs.labels }}
-        build-args: |
-          UBUNTU_MIRROR_ARCHIVE=mirror.hetzner.com/ubuntu/packages
-          UBUNTU_MIRROR_SECURITY=mirror.hetzner.com/ubuntu/security
-          UBUNTU_MIRROR_PORTS=mirror.hetzner.com/ubuntu-ports/packages
+        build-args: ${{ steps.buildarg_base.outputs.args }}
 
     - name: Build CI image
       uses: redhat-actions/buildah-build@v2
@@ -192,9 +202,9 @@ jobs:
     steps:
     - name: Print cloud service information
       run: |
-	echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
-	echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
-	echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+        echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+        echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+        echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
 
     - name: Configure temporary directory
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
+    - name: Print cloud service information
+      run: |
+	echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+	echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+	echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+
     - name: Configure temporary directory
       run: |
         mkdir -p /__w/tmp
@@ -184,6 +190,12 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Print cloud service information
+      run: |
+	echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+	echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+	echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+
     - name: Configure temporary directory
       run: |
         mkdir -p /__w/tmp


### PR DESCRIPTION
The Hetzner Ubuntu mirror is only available within the Hetzner network and thereby Hetzner-hosted runners.

This commit updates the CI workflow to specify the Hetzner Ubuntu mirror only if the scheduled runners are hosted by Hetzner.