### PR TITLE
base: Remove '--no-install-recommends' for i386 packages

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -105,7 +105,8 @@ RUN <<EOF
 			g++-multilib
 
 		# Install 32-bit dependencies
-		apt-get install --no-install-recommends -y \
+		#apt-get install --no-install-recommends -y \
+		apt-get install -y \
 			libc6-dbg:i386 \
 			libfuse-dev:i386 \
 			libsdl2-dev:i386


### PR DESCRIPTION
Specifying `--no-install-recommends` when installing i386 packages prevents APT from properly resolving all the dependencies and causes failures such as below:

 libglib2.0-dev:i386 : Depends: libglib2.0-dev-bin:i386 ...
                       Depends: libglib2.0-dev-bin-linux:i386 ...