### PR TITLE
dockerfile.base: add esptool

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -163,6 +163,7 @@ RUN <<EOF
 	pip install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
+		'esptool>=5.0.2' \
 		GitPython \
 		imgtool \
 		junitparser \


### PR DESCRIPTION
The esptool is crucial for image creation during the build. Recently the tool was moved from the hal_espressif repo into a package requirement. While build work locally, the CI is missing it and we are adding it here.