### PR TITLE
devel: Remove hard-coded ZEPHYR_BASE environment variable

### DIFF
--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -69,7 +69,6 @@ USER $USERNAME
 
 # Configure environment variables
 ENV DISPLAY=:0
-ENV ZEPHYR_BASE=/workdir/zephyr
 
 # Set working directory
 WORKDIR /workdir


### PR DESCRIPTION
This commit removes the hard-coded `ZEPHYR_BASE` environment variable from the Developer image to allow more flexibility for the user Zephyr tree layout.

With this change, it is now up to the user to provide the adequate environment configuration (e.g. setting `ZEPHYR_BASE` environment variable, or providing west configuration file with Zephyr base path) for Zephyr source root discovery.

---

Closes https://github.com/zephyrproject-rtos/docker-image/issues/162