### PR TITLE
.github: workflows: Do not fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       image: ghcr.io/zephyrproject-rtos/image-build:v1.1.0
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         variant:
         - platform: linux/amd64


### PR DESCRIPTION
Do not cancel the rest of the jobs when one of the jobs in the matrix fails.