### PR TITLE
base: Fix i386 APT package dependency hell

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -86,6 +86,13 @@ RUN <<EOF
 		openssh-client \
 		parallel \
 		pkg-config \
+		python3 \
+		python3-dev \
+		python3-pip \
+		python3-ply \
+		python3-setuptools \
+		python3-venv \
+		python-is-python3 \
 		rsync \
 		socat \
 		srecord \
@@ -100,33 +107,21 @@ RUN <<EOF
 
 	# Install x86-64 image-specific packages
 	if [ "${HOSTTYPE}" = "x86_64" ]; then
+		# Mark `python3` as held because APT otherwise tries to remove it during i386
+		# package installation.
+		apt-mark hold python3 python3-apt
+
 		# Install multi-lib gcc
 		apt-get install --no-install-recommends -y \
 			gcc-multilib \
 			g++-multilib
 
 		# Install 32-bit dependencies
-		#apt-get install --no-install-recommends -y \
-		apt-get install -y \
+		apt-get install --no-install-recommends -y \
 			libc6-dbg:i386 \
 			libfuse-dev:i386 \
 			libsdl2-dev:i386
-
-		# Ensure that software-properties-common is installed because
-		# it may be removed by the above step
-		apt-get install --no-install-recommends -y \
-			software-properties-common
 	fi
-
-	# Install Python
-	apt-get install --no-install-recommends -y \
-		python3 \
-		python3-dev \
-		python3-pip \
-		python3-ply \
-		python3-setuptools \
-		python3-venv \
-		python-is-python3
 
 	# Clean up stale packages
 	apt-get autoremove --purge -y


### PR DESCRIPTION
One of the i386 packages installed in the base Docker image depends on `python3-minimal` and APT tries to nuke the previously installed `python3` and all its friends, including `software-properties-common`, during the i386 package installation.

Marking `python3` and `python3-apt` as held seems to make APT not want to do that, and keeps `python3` and its friends in place without any hacks.

This should, hopefully, be the ultimate fix for all the i386 package dependency issues we have come across in the past.