### PR TITLE
base: install python dependencies from TF-M

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -207,9 +207,9 @@ RUN <<EOF
 	pip install --no-cache-dir \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt \
 		-r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/main/scripts/requirements.txt \
+		-r https://raw.githubusercontent.com/zephyrproject-rtos/trusted-firmware-m/main/tools/requirements.txt \
 		'esptool>=5.0.2' \
 		GitPython \
-		imgtool \
 		junitparser \
 		junit2html \
 		nrf-regtool~=9.0.1 \


### PR DESCRIPTION
Zephyr has moved to TF-M v2.2.x so, update the CI setup to install dependencies from TF-M's requirements.txt to ensure that boards like MPS4 can be built and run correctly.