### PR TITLE
base: Add libfuse3

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -101,6 +101,7 @@ RUN <<EOF
 		iproute2 \
 		lcov \
 		libcairo2-dev \
+		libfuse3-dev \
 		libglib2.0-dev \
 		libgtk2.0-0 \
 		liblocale-gettext-perl \
@@ -155,6 +156,7 @@ RUN <<EOF
 		apt-get install --no-install-recommends -y \
 			libc6-dbg:i386 \
 			libfuse-dev:i386 \
+			libfuse3-dev:i386 \
 			libsdl2-dev:i386
 	fi
 


### PR DESCRIPTION
```
fuse v3 has been out there for a few years,
and many other components have been progressively switching to it, 
while some distros have been taking an active effort to ensure they do
not use the old fuse(2) anymore and intend to deprecate it in favor of
fuse3 and remove it.

The native_sim fuse driver now can use fuse3 also, so let's install libfuse3-dev
in our docker image to do a calm and progressive transition to it.
i.e.:
1. Zephyr supports fuse3, but defaults to using v2 so we are compatible with the old image
2. The docker image starts including v3
3. Zephyr defaults to use v3
4. The docker image does not need to have v2 anymore so we remove it

1. is done
2. we'd want to do as soon as possible to enable other steps and forwards compatibility of the image
4. could then be done at any point in which we believe backwards compatibility with
older Zephyr versions is not an issue anymore (or the distro forces us because it dropped the package).
```

* https://github.com/zephyrproject-rtos/zephyr/pull/96208