### PR TITLE
base: Also install libclang-rt-*-dev

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -168,9 +168,11 @@ RUN <<EOF
 		clang-tools-${LLVM_VERSION} \
 		clangd-${LLVM_VERSION} \
 		libc++-${LLVM_VERSION}-dev \
+		libclang-rt-${LLVM_VERSION}-dev \
 		lld-${LLVM_VERSION} \
 		lldb-${LLVM_VERSION} \
-		llvm-${LLVM_VERSION}
+		llvm-${LLVM_VERSION} \
+		llvm-${LLVM_VERSION}-dev
 
 	# Install Python 3.9 for FVP
 	add-apt-repository -y ppa:deadsnakes/ppa


### PR DESCRIPTION
We forgot it in 585e01d038c58926ae55a574a4b7ec8389cd7e9f and that includes the libraries needed for building w sanitizers, fuzzer, etc.