### PR TITLE
ci: add toolchain and QEMU for Infineon TriCore CI builds

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -35,5 +35,17 @@ EOF
 
 USER root
 
+# Install TriCore GCC for AURIX (x86_64 only)
+RUN <<EOF
+	if [ "${HOSTTYPE}" = "x86_64" ]; then
+		wget ${WGET_ARGS} https://github.com/Linumiz/aurix-gcc-toolchain/releases/download/v11.3.0/aurixgcc_03-2026_Linux_x86-x64.zip
+		mkdir -p /opt/toolchains/tricore-elf
+		unzip -o aurixgcc_03-2026_Linux_x86-x64.zip -d /opt/toolchains/tricore-elf
+		chmod +x /opt/toolchains/tricore-elf/bin/*
+		chmod +x /opt/toolchains/tricore-elf/tricore-elf/bin/*
+		rm aurixgcc_03-2026_Linux_x86-x64.zip
+	fi
+EOF
+
 # Set build environment variables
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -47,5 +47,20 @@ RUN <<EOF
 	fi
 EOF
 
+# Install TriCore QEMU for AURIX (x86_64 only)
+RUN <<EOF
+	if [ "${HOSTTYPE}" = "x86_64" ]; then
+		apt-get update
+		apt-get install -y --no-install-recommends libpixman-1-0
+		wget ${WGET_ARGS} https://github.com/linumiz/qemu-tricore/releases/download/v1.0.0/qemu-tricore-linux-x86_64.tar.gz
+		mkdir -p /opt/qemu-tricore
+		tar -xzf qemu-tricore-linux-x86_64.tar.gz -C /opt/qemu-tricore
+		rm qemu-tricore-linux-x86_64.tar.gz
+		apt-get clean
+		rm -rf /var/lib/apt/lists/*
+	fi
+EOF
+ENV PATH="/opt/qemu-tricore/bin:${PATH}"
+
 # Set build environment variables
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr


### PR DESCRIPTION
This adds the TriCore GCC toolchain and a custom QEMU build to the CI
image, enabling build and test support for the Infineon AURIX TriCore
architecture port (TC3xx / TC4xx families).

Both are x86_64 only.

## Toolchain

Using tricore-elf-gcc 11.3 from Infineon (AURIX Development Studio).
This is the only freely available GCC for TriCore - all other compilers
(Hightec, Tasking, GHS, Windriver) are proprietary and closed source.
The Zephyr port uses picolibc, so no vendor C library dependency.

The official download page at [1] does not support direct wget, so the
binary is mirrored at [2] for CI access. Source for GCC 11.3 is partially
available from Infineon but there is no ongoing effort to rebase to a
newer GCC version at this point.

Installed to /opt/toolchains/tricore-elf/.

[1] https://softwaretools.infineon.com/assets/com.ifx.tb.tool.aurixgcc
[2] https://github.com/linumiz/aurix-gcc-toolchain/releases/tag/v11.3.0

## QEMU

Upstream QEMU has basic TC1.3.1 ISA support but no SoC peripherals
(no interrupt controller, no timer, no UART) and no TC1.6P/TC1.8P
instruction support. This makes it unusable for running Zephyr.

The QEMU binary provided here is built from [3], based on upstream QEMU
v11.0.0-rc4, with additions for:

- TC3xx and TC4xx SoC models (interrupt router, STM timer, SCU, ASCLIN UART)
- TC1.6.2P and TC1.8P ISA extensions (CMPSWAP, CRC32, POPCNT, DIV64,
  double-precision FPU, etc.)
- Machine models: KIT_AURIX_TC397B_TRB (TC3xx) and KIT_A3G_TC4D7_LITE (TC4xx)

This is the first open-source QEMU with SoC-level TriCore emulation
support, developed jointly with contributions from Infineon (Christoph
Seitz) and EFS (Andreas Konopik, David Brenken).

The binary is dynamically linked. The only runtime dependency not already
in the base image is libpixman-1-0.

Installed to /opt/qemu-tricore/, added to PATH.

The plan is to upstream the QEMU changes to QEMU mainline. Once upstream
QEMU has TriCore SoC support and the Zephyr SDK moves to a version that
includes it (currently on QEMU 10.x), this binary can be dropped and QEMU
for TriCore can be built from source as part of the SDK.

[3] https://github.com/linumiz/qemu-tricore/releases/tag/v1.0.0

## Context

The Zephyr TriCore architecture port is being prepared for upstream and
depends on this CI infrastructure to build and run twister tests.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>
Signed-off-by:  Christoph Seitz <christoph.seitz@infineon.com>