### PR TITLE
ci: fix tricore-elf-gcc cc1 permissions

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -41,9 +41,13 @@ RUN <<EOF
 		wget ${WGET_ARGS} https://github.com/Linumiz/aurix-gcc-toolchain/releases/download/v11.3.0/aurixgcc_03-2026_Linux_x86-x64.zip
 		mkdir -p /opt/toolchains/tricore-elf
 		unzip -o aurixgcc_03-2026_Linux_x86-x64.zip -d /opt/toolchains/tricore-elf
-		chmod +x /opt/toolchains/tricore-elf/bin/*
-		chmod +x /opt/toolchains/tricore-elf/tricore-elf/bin/*
+		chmod -R +x /opt/toolchains/tricore-elf/bin \
+		            /opt/toolchains/tricore-elf/tricore-elf/bin \
+		            /opt/toolchains/tricore-elf/libexec
 		rm aurixgcc_03-2026_Linux_x86-x64.zip
+		echo 'int main(void){return 0;}' > /tmp/__tricore_smoke.c
+		/opt/toolchains/tricore-elf/bin/tricore-elf-gcc -c /tmp/__tricore_smoke.c -o /tmp/__tricore_smoke.o
+		rm /tmp/__tricore_smoke.c /tmp/__tricore_smoke.o
 	fi
 EOF
 


### PR DESCRIPTION
The aurix-gcc-toolchain release zip ships libexec/ contents without the unix exec bit. The previous chmod only covered bin/ and tricore-elf/bin/, leaving cc1, cc1plus, lto1, lto-wrapper and collect2 non-executable. Result was a hard-to-diagnose failure during devicetree preprocessing:

  tricore-elf-gcc: fatal error: cannot execute 'cc1': execvp: No such file or directory

Recursively chmod +x the three known dirs and add a smoke compile at image build time so this never silently passes again.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>