### PR TITLE
Feat: cargo available for user

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -379,13 +379,15 @@ EOF
 
 ENV ARMFVP_BIN_PATH=/usr/local/bin
 
+# Make Cargo available globally
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
 # Set up Rust
 RUN <<EOF
 	# Install Cargo package manager
 	wget -q -O- "https://sh.rustup.rs" | sh -s -- -y --default-toolchain 1.86
-
-	# Make Cargo globally available for subsequent steps
-	PATH=~/.cargo/bin:$PATH
 
 	# Install uefi-run utility
 	cargo install uefi-run --root /usr
@@ -398,6 +400,9 @@ RUN <<EOF
 	rustup target install thumbv7m-none-eabi
 	rustup target install thumbv8m.main-none-eabi
 	rustup target install x86_64-unknown-none
+
+	# Allow all users to write to the shared rustup and cargo homes (registry cache, toolchains, etc.)
+	chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 EOF
 
 # Create user account

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -239,6 +239,9 @@ RUN <<EOF
 	if [ "${HOSTTYPE}" = "x86_64" ]; then
 		pip check
 	fi
+
+	# Symlink west to /usr/local/bin so it is available in shells that reset PATH (e.g. sudo su)
+	ln -s ${PYTHON_VENV_PATH}/bin/west /usr/local/bin
 EOF
 
 # Make Zephyr Python virtual environment available globally
@@ -403,6 +406,14 @@ RUN <<EOF
 
 	# Allow all users to write to the shared rustup and cargo homes (registry cache, toolchains, etc.)
 	chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+
+	# Symlink cargo and rustup to /usr/local/bin so they are available in shells that reset PATH (e.g. sudo su)
+	ln -s /usr/local/cargo/bin/cargo /usr/local/bin
+	ln -s /usr/local/cargo/bin/rustup /usr/local/bin
+
+	# Persist RUSTUP_HOME and CARGO_HOME to /etc/environment so they survive sudo env_reset (e.g. sudo su)
+	echo 'RUSTUP_HOME=/usr/local/rustup' >> /etc/environment
+	echo 'CARGO_HOME=/usr/local/cargo' >> /etc/environment
 EOF
 
 # Create user account


### PR DESCRIPTION
#### Commit 1/2

Make cargo available for `user` out-of-the-box by using `RUSTUP_HOME`  and `CARGO_HOME` the way it is done in [rust-lang/docker-rust/refs/heads/master/Dockerfile-slim.template](https://raw.githubusercontent.com/rust-lang/docker-rust/refs/heads/master/Dockerfile-slim.template).

#### Commit 2/2

Add symlinks and persist env vars to support west and cargo builds via `sudo su`.

---

closes https://github.com/zephyrproject-rtos/docker-image/issues/306